### PR TITLE
Recommend pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ Progress Bar Component for Android Devices
 ## Getting started
 
 ```
-$ npm install @react-native-community/progress-bar-android --save
-```
+npm install @react-native-community/progress-bar-android --save
 
-or
+# or 
 
-```
-$ yarn add @react-native-community/progress-bar-android
+yarn add @react-native-community/progress-bar-android
 ```
 
 ### Linking
@@ -30,7 +28,7 @@ $ yarn add @react-native-community/progress-bar-android
  The package is [automatically linked](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) when building the app. All you need to do is:
 
 ```
-$ cd ios && pod install
+npx pod-install
 ```
 
 - React Native <= 0.59


### PR DESCRIPTION
# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`